### PR TITLE
Dev (workaround)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,17 @@ jobs:
       matrix:
         julia-version:
           - "1.8.5"
+          - "1.2.0"
+          - "1.3.1"
+          - "1.5.3"
           - "1.6.7" # LTS
           - "1" # automatically expands to the latest stable 1.x release of Julia
           - nightly
         os: [ubuntu-latest, macOS-latest]
 
     steps:
+      - name: Setup GNU Fortran
+        uses: modflowpy/install-gfortran-action@v1
       - uses: actions/checkout@v3
       - name: "Set up Julia"
         uses: julia-actions/setup-julia@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  test:
+    name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version:
+          - "1.8.5"
+          - "1.6.7" # LTS
+          - "1" # automatically expands to the latest stable 1.x release of Julia
+          - nightly
+        os: [ubuntu-latest, macOS-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Set up Julia"
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          annotate: true

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,44 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MPBNGCInterface"
 uuid = "a69a4381-f1fe-46fe-a0d9-fb198c411755"
-authors = ["Johannes Milz <milz@ma.tum.de>"]
+authors = ["Johannes Milz"]
 version = "0.1.0"
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,10 @@
+name = "MPBNGCInterface"
+uuid = "a69a4381-f1fe-46fe-a0d9-fb198c411755"
+authors = ["Johannes Milz <milz@ma.tum.de>"]
+version = "0.1.0"
+
+[deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ cd ..
 ```
 
 These commands should download the module and compile
-the Bundle method if you have `gfortran` installed. 
+the Bundle method *if* you have `gfortran` installed. 
+
 The code `build.jl` located in `deps`
 when executed attempts to download the
 [source code](http://napsu.karmitsa.fi/proxbundle/pb/mpbngc.tar.gz)
@@ -53,7 +54,7 @@ of the
 [Proximal Bundle Method `MPBNGC`](http://napsu.karmitsa.fi/proxbundle/)
 and tries to compile it together with its dependencies.
 
-To add `MPBNGCInterface` to Julia's path, we can use
+To add `MPBNGCInterface` to Julia's path, 
 
 ```
 julia -e "import Pkg; path = pwd(); Pkg.add(path=path)"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ To download `MPBNGCInterface.jl`, compile `MPBNGC`, and add
 ```
 git clone -b dev https://github.com/milzj/MPBNGCInterface.jl.git
 cd MPBNGCInterface.jl
+cd deps
+julia build.jl
+cd ..
 julia -e "import Pkg; path = pwd(); Pkg.add(path=path)"
 ```
 
@@ -58,7 +61,6 @@ and tries to compile it together with its dependencies.
 To run the tests, we can then execute in the Pkg REPL,
 ```julia
 test MPBNGCInterface
-
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and `C'` is the transposed of `C`.
 ## Installation
 
 For `Julia` version above `1.3`, `MPBNGCInterface.jl` cannot be installed using the
-[Julia Package Manager](https://docs.julialang.org/en/v1/stdlib/Pkg/index.html):
+[Julia Package Manager](https://docs.julialang.org/en/v1/stdlib/Pkg/index.html).
 
 To download `MPBNGCInterface.jl` and compile `MPBNGC`, 
 the following commands can be executed in a terminal:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![MPBNGCInterface.jl Tests](https://github.com/milzj/MPBNGCInterface.jl/actions/workflows/test.yml/badge.svg)
 
 # MPBNGCInterface.jl
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,12 @@ and `C'` is the transposed of `C`.
 For `Julia` version above `1.3`, `MPBNGCInterface.jl` cannot be installed using the
 [Julia Package Manager](https://docs.julialang.org/en/v1/stdlib/Pkg/index.html).
 
-To download `MPBNGCInterface.jl` and compile `MPBNGC`, 
-the following commands can be executed in a terminal:
+To download `MPBNGCInterface.jl`, compile `MPBNGC`, and add
+`MPBNGCInterface` to Julia's path, the following commands can be executed in a terminal:
 
 ```
 git clone https://github.com/milzj/MPBNGCInterface.jl.git@devel
-cd deps
-julia build.jl
-cd ..
+julia -e "import Pkg; path = pwd(); Pkg.add(path=path)"
 ```
 
 These commands should download the module and compile
@@ -55,16 +53,10 @@ of the
 [Proximal Bundle Method `MPBNGC`](http://napsu.karmitsa.fi/proxbundle/)
 and tries to compile it together with its dependencies.
 
-To add `MPBNGCInterface` to Julia's path, 
 
-```
-julia -e "import Pkg; path = pwd(); Pkg.add(path=path)"
-```
-
-To run the tests, we can then execute
-```
-cd test
-julia  runtests.jl
+To run the tests, we can then execute in the Pkg REPL,
+```julia
+test MPBNGCInterface
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![MPBNGCInterface.jl Tests](https://github.com/milzj/MPBNGCInterface.jl/actions/workflows/test.yml/badge.svg)
+[![MPBNGCInterface.jl Tests](https://github.com/milzj/MPBNGCInterface.jl/actions/workflows/test.yml/badge.svg)](https://github.com/milzj/MPBNGCInterface.jl/actions)
 
 # MPBNGCInterface.jl
 

--- a/README.md
+++ b/README.md
@@ -31,22 +31,40 @@ and `C'` is the transposed of `C`.
 
 ## Installation
 
-You can install `MPBNGCInterface.jl` through the 
+For `Julia` version above `1.3`, `MPBNGCInterface.jl` cannot be installed using the
 [Julia Package Manager](https://docs.julialang.org/en/v1/stdlib/Pkg/index.html):
 
-```julia
-] add https://github.com/milzj/MPBNGCInterface.jl.git
+To download `MPBNGCInterface.jl` and compile `MPBNGC`, 
+the following commands can be executed in a terminal:
+
+```
+git clone https://github.com/milzj/MPBNGCInterface.jl.git@devel
+cd deps
+julia build.jl
+cd ..
 ```
 
-The command should download the module and compile
+These commands should download the module and compile
 the Bundle method if you have `gfortran` installed. 
-
 The code `build.jl` located in `deps`
 when executed attempts to download the
 [source code](http://napsu.karmitsa.fi/proxbundle/pb/mpbngc.tar.gz)
 of the 
 [Proximal Bundle Method `MPBNGC`](http://napsu.karmitsa.fi/proxbundle/)
 and tries to compile it together with its dependencies.
+
+To add `MPBNGCInterface` to Julia's path, we can use
+
+```
+julia -e "import Pkg; path = pwd(); Pkg.add(path=path)"
+```
+
+To run the tests, we can then execute
+```
+cd test
+julia  runtests.jl
+```
+
 
 The module is an unregistered Julia package. It has successfully been tested
 on Linux and Mac OS using [Travics CI](https://travis-ci.com/)
@@ -59,7 +77,7 @@ Moreover, it has been tested on Windows 10 Education (version 10.0.16299) (64bit
 This code uses `gfortran` to compile the 
 [Proximal Bundle Method `MPBNGC`](http://napsu.karmitsa.fi/proxbundle/).
 
-The interface does not support other compiles than `gfortan`.
+The interface does not support compilers other than `gfortan`.
 
 ## Custom Installation
 
@@ -153,5 +171,4 @@ large parts of his [ODEInterface.jl](https://github.com/luchr/ODEInterface.jl) c
 
 ## Author
 
-The module has been implemented by 
-[Johannes Milz](https://www-m1.ma.tum.de/bin/view/Lehrstuhl/JohannesMilz).
+The module has been implemented by Johannes Milz.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To download `MPBNGCInterface.jl`, compile `MPBNGC`, and add
 `MPBNGCInterface` to Julia's path, the following commands can be executed in a terminal:
 
 ```
-git clone https://github.com/milzj/MPBNGCInterface.jl.git@dev
+git clone -b dev https://github.com/milzj/MPBNGCInterface.jl.git
 cd MPBNGCInterface.jl
 julia -e "import Pkg; path = pwd(); Pkg.add(path=path)"
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To download `MPBNGCInterface.jl`, compile `MPBNGC`, and add
 `MPBNGCInterface` to Julia's path, the following commands can be executed in a terminal:
 
 ```
-git clone https://github.com/milzj/MPBNGCInterface.jl.git@devel
+git clone https://github.com/milzj/MPBNGCInterface.jl.git@dev
 cd MPBNGCInterface.jl
 julia -e "import Pkg; path = pwd(); Pkg.add(path=path)"
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ and `C'` is the transposed of `C`.
 
 ## Installation
 
+You can install `MPBNGCInterface.jl` through the 
+[Julia Package Manager](https://docs.julialang.org/en/v1/stdlib/Pkg/index.html)
+by executing the following command in the Pkg REPL:
+
+```julia
+add https://github.com/milzj/MPBNGCInterface.jl.git#dev
+```
+
+The command should download the module and compile
+the Bundle method if you have `gfortran` installed. 
+
+The code `build.jl` located in `deps`
+when executed attempts to download the
+[source code](http://napsu.karmitsa.fi/proxbundle/pb/mpbngc.tar.gz)
+of the 
+[Proximal Bundle Method `MPBNGC`](http://napsu.karmitsa.fi/proxbundle/)
+and tries to compile it together with its dependencies.
+
 For `Julia` version above `1.3`, `MPBNGCInterface.jl` cannot be installed using the
 [Julia Package Manager](https://docs.julialang.org/en/v1/stdlib/Pkg/index.html).
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To download `MPBNGCInterface.jl`, compile `MPBNGC`, and add
 
 ```
 git clone https://github.com/milzj/MPBNGCInterface.jl.git@devel
+cd MPBNGCInterface.jl
 julia -e "import Pkg; path = pwd(); Pkg.add(path=path)"
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ and tries to compile it together with its dependencies.
 To run the tests, we can then execute in the Pkg REPL,
 ```julia
 test MPBNGCInterface
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ add https://github.com/milzj/MPBNGCInterface.jl.git#dev
 ```
 
 The command should download the module and compile
-the Bundle method if you have `gfortran` installed. 
+the Bundle method **if** you have `gfortran` installed. 
 
 The code `build.jl` located in `deps`
 when executed attempts to download the
@@ -49,32 +49,6 @@ when executed attempts to download the
 of the 
 [Proximal Bundle Method `MPBNGC`](http://napsu.karmitsa.fi/proxbundle/)
 and tries to compile it together with its dependencies.
-
-For `Julia` version above `1.3`, `MPBNGCInterface.jl` cannot be installed using the
-[Julia Package Manager](https://docs.julialang.org/en/v1/stdlib/Pkg/index.html).
-
-To download `MPBNGCInterface.jl`, compile `MPBNGC`, and add
-`MPBNGCInterface` to Julia's path, the following commands can be executed in a terminal:
-
-```
-git clone -b dev https://github.com/milzj/MPBNGCInterface.jl.git
-cd MPBNGCInterface.jl
-cd deps
-julia build.jl
-cd ..
-julia -e "import Pkg; path = pwd(); Pkg.add(path=path)"
-```
-
-These commands should download the module and compile
-the Bundle method *if* you have `gfortran` installed. 
-
-The code `build.jl` located in `deps`
-when executed attempts to download the
-[source code](http://napsu.karmitsa.fi/proxbundle/pb/mpbngc.tar.gz)
-of the 
-[Proximal Bundle Method `MPBNGC`](http://napsu.karmitsa.fi/proxbundle/)
-and tries to compile it together with its dependencies.
-
 
 To run the tests, we can then execute in the Pkg REPL,
 ```julia


### PR DESCRIPTION
Added [Project.toml](https://github.com/milzj/MPBNGCInterface.jl/blob/dev/Project.toml), [Manifest.toml](https://github.com/milzj/MPBNGCInterface.jl/blob/dev/Manifest.toml) and [test.yml](https://github.com/milzj/MPBNGCInterface.jl/blob/dev/.github/workflows/test.yml). 

The changes implement a workaround. It would be nice to use precompiled Fortran codes (generated using https://github.com/JuliaPackaging/BinaryBuilder.jl) (see also https://github.com/luchr/ODEInterface.jl), as this is Julia's default for Julia versions >= 1.3.